### PR TITLE
Add deprecation warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,11 @@
 
 	<object id='overlaySvg' data="all.svg" type="image/svg+xml"></object>
 
+  <div id='deprecation-warning'>
+    NOTICE: This map is outdated. To view the new map, follow this link:
+    <a href='https://maps.umass.edu/parking/'>https://maps.umass.edu/parking/</a>
+  </div>
+
 	<div id='header'>
 		<div id="umass-logo">
 			<a href="http://umass.edu/" title='UMass Amherst'>

--- a/stylesheets/map.css
+++ b/stylesheets/map.css
@@ -26,6 +26,13 @@ fieldset{
 	padding: 0;
 	border: none;
 }
+#deprecation-warning {
+  background-color: #dc3545;
+  font-size: 1.5rem;
+  font-weight: bold;
+  padding: 1rem;
+}
+
 #header{
 	width: 100%;
 	height: 70px;


### PR DESCRIPTION
**Wait till 2019-11-13 to merge this!**
We should ensure that Sasha has updated the link to `/parking/` instead of `/parking/beta/` before.

Since this is being replaced by https://github.com/umts/GISMap. Looks roughly like this, except the page will be working in production:

<img width="1278" alt="Screen Shot 2019-11-04 at 10 17 04 AM" src="https://user-images.githubusercontent.com/7032019/68133426-56983d00-feee-11e9-9d5f-11d512d36a21.png">
